### PR TITLE
GPU over 100% workaround

### DIFF
--- a/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
@@ -26,8 +26,27 @@ GraphMeasure5=MeasureGPU
 ; ------------------------------------------------------------------------
 ; MEASURES
 ; ------------------------------------------------------------------------
+; Usage
 
-[MeasureGPUTotal]
+[MeasureGPU]
+Measure=Calc
+Formula=MeasureGPU_UsageMonitor
+;
+IfCondition=MeasureGPU_UsageMonitor > 0
+IfTrueAction=[!SetOption MeasureGPU Formula MeasureGPU_UsageMonitor]
+;
+IfCondition2=MeasureGPU_HWiNFO > 0
+IfTrueAction2=[!SetOption MeasureGPU Formula MeasureGPU_HWiNFO]
+;
+IfCondition3=MeasureGPU_MSIAfterburner > 0
+IfTrueAction3=[!SetOption MeasureGPU Formula MeasureGPU_MSIAfterburner]
+;
+OnUpdateAction=[!UpdateMeter Graph5][!UpdateMeter GraphBackground5][!UpdateMeter Value5]
+MaxValue=100
+MinValue=0
+
+[MeasureGPU_UsageMonitor]
+; This is buggy and sometimes displays over 100%
 Measure=Plugin
 Plugin=UsageMonitor
 Alias=GPU
@@ -37,12 +56,29 @@ UpdateDivider=10
 MaxValue=100
 MinValue=0
 
-[MeasureGPU]
-Measure=Calc
-Formula=MeasureGPUTotal
-OnUpdateAction=[!UpdateMeter Graph5][!UpdateMeter GraphBackground5][!UpdateMeter Value5]
-MaxValue=100
-MinValue=0
+[MeasureGPU_HWiNFO]
+; Returns the Usage of the GPU using HWiNFO
+; If the Temperature is not shown even though HWiNFO is running and the HWiNFO.dll is installed
+; Change the Values below according to HWiNFOSharedMemoryViewer.exe included in the HWiNFO Demo Skin
+Measure=Plugin
+Plugin=HWiNFO.dll
+HWiNFOSensorId=0xe0002000
+HWiNFOSensorInstance=0x0
+HWiNFOEntryId=0x7000000
+;
+HWiNFOType=CurrentValue
+OnUpdateAction=[!UpdateMeasure MeasureGPU]
+UpdateDivider=10
+
+[MeasureGPU_MSIAfterburner]
+; Returns the Usage of the GPU using MSIAfterburner
+Measure=Plugin
+Plugin=MSIAfterburner.dll
+DataSource=GPU usage
+OnUpdateAction=[!UpdateMeasure MeasureGPU]
+UpdateDivider=10
+
+; Temperature
 
 [MeasureGPUTemp]
 ; Pulls Info About the GPU Temperature if possible
@@ -75,7 +111,7 @@ UpdateDivider=10
 [MeasureGPUTemp_HWiNFO]
 ; Returns the Temperature of the GPU using HWiNFO
 ; If the Temperature is not shown even though HWiNFO is running and the HWiNFO.dll is installed
-; Change the Values below according to HWiNFOSharedMemoryViewer.exe
+; Change the Values below according to HWiNFOSharedMemoryViewer.exe included in the HWiNFO Demo Skin
 Measure=Plugin
 Plugin=HWiNFO.dll
 HWiNFOSensorId=0xe0002000


### PR DESCRIPTION
Now the GPU Widget gets the GPU Usage data from either MSIAfterburner, HWiNFO or UsageMonitor
UsageMonitor is not usable for everyone. For some the Total GPU Usage is listed in perfmon.exe for some it is not. Couldn't figure out how to fix it, so I switched to measuring the usage via MSIAfterburner (HWiNFO is possible too)