### PR TITLE
Add Fan RPM measure

### DIFF
--- a/Win10 Widgets/@Resources/Performance Templates/cpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/cpuTemplate.ini
@@ -49,7 +49,6 @@ IfFalseAction4=[!SetOption Value1 Text "%1%"]
 OnUpdateAction=[!UpdateMeter Value1]
 UpdateDivider=10
 
-
 [MeasureCPUTemp_SpeedFan]
 ; Returns the Temperature of the CPU using SpeedFan
 ; If the Temperature is not shown even though SpeedFan is running
@@ -75,7 +74,6 @@ HWiNFOType=CurrentValue
 OnUpdateAction=[!UpdateMeasure MeasureCPUTemp]
 UpdateDivider=10
 
-
 [MeasureCPUTemp_CoreTemp]
 ; Returns the Temperature of the Hottest CPU Core using CoreTemp
 Measure=Plugin
@@ -83,6 +81,31 @@ Plugin=CoreTemp
 OnUpdateAction=[!UpdateMeasure MeasureCPUTemp]
 UpdateDivider=10
 
+[MeasureCPUFanRPM]
+; Pulls Info About the CPU Fan RPM if possible
+Measure=Calc
+Formula=0
+IfCondition=MeasureCPUFanRPM_HWiNFO > 0
+IfTrueAction=[!SetOption MeasureCPUFanRPM Formula MeasureCPUFanRPM_HWiNFO]
+IfCondition2=MeasureCPUFanRPM > 0
+IfTrueAction2=[!SetOption FanSpeed1 Text "%1 rpm"][!SetOption FanSpeed1 Hidden 0]
+IfFalseAction2=[!SetOption FanSpeed1 Hidden 1]
+OnUpdateAction=[!UpdateMeter FanSpeed1]
+UpdateDivider=10
+
+[MeasureCPUFanRPM_HWiNFO]
+; Returns the FanSpeed of the GPU using HWiNFO
+; If the Speed is not shown even though HWiNFO is running and the HWiNFO.dll is installed
+; Change the Values below according to HWiNFOSharedMemoryViewer.exe included in the HWiNFO Demo Skin
+Measure=Plugin
+Plugin=HWiNFO.dll
+HWiNFOSensorId=0xf7067960
+HWiNFOSensorInstance=0x0
+HWiNFOEntryId=0x3000001
+;
+HWiNFOType=CurrentValue
+OnUpdateAction=[!UpdateMeasure MeasureCPUFanRPM]
+UpdateDivider=1
 
 ; ------------------------------------------------------------------------
 ; METERS
@@ -111,4 +134,12 @@ Hidden=0
 
 [Value1]
 MeasureName2=MeasureCPUTemp
+ClipString=2
+ClipStringW=(#BackgroundWidth#-[#CURRENTSECTION#:X]-6)
+Hidden=0
+
+[FanSpeed1]
+MeasureName=MeasureCPUFanRPM
+ClipString=2
+ClipStringW=(#BackgroundWidth#-[#CURRENTSECTION#:X]-6)
 Hidden=0

--- a/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
@@ -91,7 +91,7 @@ IfTrueAction2=[!SetOption MeasureGPUTemp Formula MeasureGPUTemp_HWiNFO]
 IfCondition3=MeasureGPUTemp_MSIAfterburner > 0
 IfTrueAction3=[!SetOption MeasureGPUTemp Formula MeasureGPUTemp_MSIAfterburner]
 IfCondition4=MeasureGPUTemp > 0
-IfTrueAction4=[!SetOption Value5 Text "%1% (%2[\x00B0]C) #CRLF#%3 rpm"]
+IfTrueAction4=[!SetOption Value5 Text "%1% (%2[\x00B0]C)"]
 IfFalseAction4=[!SetOption Value5 Text "%1%"]
 OnUpdateAction=[!UpdateMeter Value5]
 UpdateDivider=10
@@ -122,6 +122,28 @@ HWiNFOType=CurrentValue
 OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
 UpdateDivider=10
 
+[MeasureGPUTemp_MSIAfterburner]
+; Returns the Temperature of the GPU using MSIAfterburner
+Measure=Plugin
+Plugin=MSIAfterburner.dll
+DataSource=GPU temperature
+OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
+UpdateDivider=10
+
+[MeasureGPUFanRPM]
+; Pulls Info About the GPU FanSpeed if possible
+Measure=Calc
+Formula=0
+IfCondition=MeasureGPUFanRPM_HWiNFO > 0
+IfTrueAction=[!SetOption MeasureGPUFanRPM Formula MeasureGPUFanRPM_HWiNFO]
+IfCondition2=MeasureGPUTemp_MSIAfterburner > 0
+IfTrueAction2=[!SetOption MeasureGPUFanRPM Formula MeasureGPUFanRPM_MSIAfterburner]
+IfCondition3=MeasureGPUFanRPM > 0
+IfTrueAction3=[!SetOption FanSpeed5 Text "%1 rpm"][!SetOption FanSpeed5 Hidden 0]
+IfFalseAction3=[!SetOption FanSpeed5 Hidden 1]
+OnUpdateAction=[!UpdateMeter FanSpeed5]
+UpdateDivider=10
+
 [MeasureGPUFanRPM_HWiNFO]
 Measure=Plugin
 Plugin=HWiNFO.dll
@@ -132,19 +154,11 @@ HWiNFOType=CurrentValue
 OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
 UpdateDivider=10
 
-[MeasureGPUTemp_MSIAfterburner]
-; Returns the Temperature of the GPU using MSIAfterburner
-Measure=Plugin
-Plugin=MSIAfterburner.dll
-DataSource=GPU temperature
-OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
-UpdateDivider=10
-
 [MeasureGPUFanRPM_MSIAfterburner]
 Measure=Plugin
 Plugin=MSIAfterburner.dll
 DataSource=Fan tachometer
-OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
+OnUpdateAction=[!UpdateMeasure MeasureGPUFanRPM]
 UpdateDivider=10
 
 ; ------------------------------------------------------------------------
@@ -174,8 +188,10 @@ Hidden=0
 
 [Value5]
 MeasureName2=MeasureGPUTemp
-;MeasureName3=MeasureGPUFanRPM_MSIAfterburner
-MeasureName3=MeasureGPUFanRPM_HWiNFO
 ClipString=2
 ClipStringW=(#BackgroundWidth#-[#CURRENTSECTION#:X]-6)
+Hidden=0
+
+[FanSpeed5]
+MeasureName=MeasureGPUFanRPM
 Hidden=0

--- a/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
@@ -91,7 +91,7 @@ IfTrueAction2=[!SetOption MeasureGPUTemp Formula MeasureGPUTemp_HWiNFO]
 IfCondition3=MeasureGPUTemp_MSIAfterburner > 0
 IfTrueAction3=[!SetOption MeasureGPUTemp Formula MeasureGPUTemp_MSIAfterburner]
 IfCondition4=MeasureGPUTemp > 0
-IfTrueAction4=[!SetOption Value5 Text "%1% (%2[\x00B0]C)"]
+IfTrueAction4=[!SetOption Value5 Text "%1% (%2[\x00B0]C) #CRLF#%3 rpm"]
 IfFalseAction4=[!SetOption Value5 Text "%1%"]
 OnUpdateAction=[!UpdateMeter Value5]
 UpdateDivider=10
@@ -122,11 +122,28 @@ HWiNFOType=CurrentValue
 OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
 UpdateDivider=10
 
+[MeasureGPUFanRPM_HWiNFO]
+Measure=Plugin
+Plugin=HWiNFO.dll
+HWiNFOSensorId=0xe0002000
+HWiNFOSensorInstance=0x0
+HWiNFOEntryId=0x3000000
+HWiNFOType=CurrentValue
+OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
+UpdateDivider=10
+
 [MeasureGPUTemp_MSIAfterburner]
 ; Returns the Temperature of the GPU using MSIAfterburner
 Measure=Plugin
 Plugin=MSIAfterburner.dll
 DataSource=GPU temperature
+OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
+UpdateDivider=10
+
+[MeasureGPUFanRPM_MSIAfterburner]
+Measure=Plugin
+Plugin=MSIAfterburner.dll
+DataSource=Fan tachometer
 OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
 UpdateDivider=10
 
@@ -157,4 +174,8 @@ Hidden=0
 
 [Value5]
 MeasureName2=MeasureGPUTemp
+;MeasureName3=MeasureGPUFanRPM_MSIAfterburner
+MeasureName3=MeasureGPUFanRPM_HWiNFO
+ClipString=2
+ClipStringW=(#BackgroundWidth#-[#CURRENTSECTION#:X]-6)
 Hidden=0

--- a/Win10 Widgets/@Resources/Performance Templates/performanceTemplateX4.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/performanceTemplateX4.ini
@@ -55,6 +55,7 @@ GraphLabel4="Network"
 GraphLeftPadding5=11
 GraphTopPadding5=11
 GraphMeasure5=EmptyMeasure
+GraphMeasure5rpm=EmptyMeasure
 GraphColor5=#GPURed#
 GraphLabel5="GPU"
 
@@ -163,6 +164,18 @@ X=1r
 Y=-2R
 Group=Monitor1
 Text="%1%"
+FontSize=9
+Hidden=1
+
+[FanSpeed1]
+; Value corresponding to graph.
+Meter=String
+MeterStyle=StyleSmallText | StyleForegroundText
+MeasureName=#GraphMeasure1rpm#
+X=0r
+Y=-4R
+Group=Monitor1
+Text="%1 rpm"
 FontSize=9
 Hidden=1
 
@@ -558,5 +571,17 @@ X=1r
 Y=-2R
 Group=Monitor5
 Text="%1%"
+FontSize=9
+Hidden=1
+
+[FanSpeed5]
+; Value corresponding to graph.
+Meter=String
+MeterStyle=StyleSmallText | StyleForegroundText
+MeasureName=#GraphMeasure5rpm#
+X=0r
+Y=-4R
+Group=Monitor5
+Text="%1 rpm"
 FontSize=9
 Hidden=1

--- a/Win10 Widgets/@Resources/variables.ini
+++ b/Win10 Widgets/@Resources/variables.ini
@@ -24,9 +24,9 @@ Version2=0
 Version3=0
 ; Begin Dimensions
 tiniestHeight=50
-tinyHeight=62
+tinyHeight=66
 smallHeight=90
-mediumHeight=117
+mediumHeight=127
 largeHeight=165
 largestHeight=200
 ;

--- a/Win10 Widgets/Performance - CPU/CPU-Large.ini
+++ b/Win10 Widgets/Performance - CPU/CPU-Large.ini
@@ -43,5 +43,12 @@ Y=4
 MeterStyle=StyleMediumText
 X=0R
 Y=16r
-FontSize=18
+FontSize=16
+FontColor=#ForegroundFaintColor#
+
+[FanSpeed1]
+MeterStyle=StyleMediumText
+X=1R
+Y=0r
+FontSize=16
 FontColor=#ForegroundFaintColor#

--- a/Win10 Widgets/Performance - CPU/CPU-Medium.ini
+++ b/Win10 Widgets/Performance - CPU/CPU-Medium.ini
@@ -41,3 +41,7 @@ Y=6
 
 [Value1]
 Y=7r
+
+[FanSpeed1]
+X=15R
+Y=0r

--- a/Win10 Widgets/Performance - CPU/CPU-Small.ini
+++ b/Win10 Widgets/Performance - CPU/CPU-Small.ini
@@ -25,7 +25,7 @@ Version=1.0.0
 
 [Variables]
 @Include=CPU-Tiny.ini
-BackgroundHeight=#smallHeight#
+BackgroundHeight=91
 GraphWidth=339
 GraphTopPadding1=40
 
@@ -42,3 +42,8 @@ Y=10
 FontSize=11
 X=5R
 Y=0r
+
+[FanSpeed1]
+FontSize=11
+X=12R
+Y=10

--- a/Win10 Widgets/Performance - CPU/CPU-Tiny.ini
+++ b/Win10 Widgets/Performance - CPU/CPU-Tiny.ini
@@ -22,7 +22,6 @@
 
 [Rainmeter]
 Update=100
-DefaultUpdateDivider=-1
 
 [Metadata]
 Name=CPU (tiny)

--- a/Win10 Widgets/Performance - Combo/Combo-Thin.ini
+++ b/Win10 Widgets/Performance - Combo/Combo-Thin.ini
@@ -25,14 +25,14 @@ Version=1.0.0
 
 [Variables]
 @Include=Combo.ini
-BackgroundHeight=262
+BackgroundHeight=272
 BackgroundWidth=#smallWidth#
 FirstColumnLeftPadding=11
 FirstRowTopPadding=11
-SecondRowTopPadding=61
-ThirdRowTopPadding=111
-FourthRowTopPadding=161
-FifthRowTopPadding=211
+SecondRowTopPadding=66
+ThirdRowTopPadding=116
+FourthRowTopPadding=166
+FifthRowTopPadding=219
 ; CPU Variables
 GraphLeftPadding1=#FirstColumnLeftPadding#
 GraphTopPadding1=#FirstRowTopPadding#

--- a/Win10 Widgets/Performance - Combo/Combo.ini
+++ b/Win10 Widgets/Performance - Combo/Combo.ini
@@ -40,13 +40,13 @@ Version=1.0.0
 @Include5="#@#Performance Templates\networkTemplate.ini"
 @Include6="#@#Performance Templates\gpuTemplate.ini"
 CoreFilePath=""#CURRENTPATH#Combo.ini""
-BackgroundHeight=#largeHeight#
+BackgroundHeight=#mediumHeight#+50
 AutoBorder=1
 FirstColumnLeftPadding=11
 SecondColumnLeftPadding=160
 FirstRowTopPadding=11
-SecondRowTopPadding=61
-ThirdRowTopPadding=111
+SecondRowTopPadding=67
+ThirdRowTopPadding=117
 ; CPU Variables
 GraphLeftPadding1=#FirstColumnLeftPadding#
 GraphTopPadding1=#FirstRowTopPadding#
@@ -62,6 +62,10 @@ GraphTopPadding4=#SecondRowTopPadding#
 ; GPU Variables
 GraphLeftPadding5=#FirstColumnLeftPadding#
 GraphTopPadding5=#ThirdRowTopPadding#
+NetworkUnitMultiplier=8
+NetworkKBUnit=Kbps
+NetworkMBUnit=Mbps
+NetworkGBUnit=Gbps
 
 
 ; ------------------------------------------------------------------------

--- a/Win10 Widgets/Performance - GPU/GPU-Large.ini
+++ b/Win10 Widgets/Performance - GPU/GPU-Large.ini
@@ -43,5 +43,12 @@ Y=4
 MeterStyle=StyleMediumText
 X=0R
 Y=16r
-FontSize=18
+FontSize=16
+FontColor=#ForegroundFaintColor#
+
+[FanSpeed5]
+MeterStyle=StyleMediumText
+X=1R
+Y=0r
+FontSize=16
 FontColor=#ForegroundFaintColor#

--- a/Win10 Widgets/Performance - GPU/GPU-Medium.ini
+++ b/Win10 Widgets/Performance - GPU/GPU-Medium.ini
@@ -41,3 +41,9 @@ Y=6
 
 [Value5]
 Y=7r
+
+[FanSpeed5]
+MeterStyle=StyleMediumText
+X=15R
+Y=0r
+FontColor=#ForegroundFaintColor#

--- a/Win10 Widgets/Performance - GPU/GPU-Small.ini
+++ b/Win10 Widgets/Performance - GPU/GPU-Small.ini
@@ -42,3 +42,8 @@ Y=10
 FontSize=11
 X=5R
 Y=0r
+
+[FanSpeed5]
+FontSize=11
+X=12R
+Y=0r


### PR DESCRIPTION
This adds the Fan RPM to the GPU measure. Currently it's not dynamic so depending on whether you use MSI Afterburner or HWiNFO, you will need to change MeasureName3 under [Value5] in `/Performance Templates/gpuTemplate.ini`

The RPM are shown in a new line below the Temperature, which looks best in the Performance - Combo skin.

![image](https://user-images.githubusercontent.com/1574126/91657237-ef7cf200-ead8-11ea-83a7-7e3a47f4bbdc.png)

Possible improvements
- Get Fan RPM data automatically
- Show in one line on the standalone GPU skins to prevent overflowing text