### PR TITLE
CPU and GPU fan speed

### DIFF
--- a/Win10 Widgets/@Resources/Performance Templates/cpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/cpuTemplate.ini
@@ -83,6 +83,35 @@ Plugin=CoreTemp
 OnUpdateAction=[!UpdateMeasure MeasureCPUTemp]
 UpdateDivider=10
 
+[MeasureCPUFanRPM]
+; Pulls Info About the GPU FanSpeed if possible
+Measure=Calc
+Formula=0
+IfCondition=MeasureCPUFanRPM_HWiNFO > -1
+IfTrueAction=[!SetOption MeasureCPUFanRPM Formula MeasureCPUFanRPM_HWiNFO]
+;IfCondition2=MeasureGPUTemp_HWiNFO > 0
+;IfTrueAction2=[!SetOption MeasureCPUFanRPM Formula MeasureGPUTemp_HWiNFO]
+;IfCondition3=MeasureGPUTemp_MSIAfterburner > 0
+;IfTrueAction3=[!SetOption MeasureCPUFanRPM Formula MeasureGPUTemp_MSIAfterburner]
+IfCondition2=MeasureCPUFanRPM > -1
+IfTrueAction2=[!SetOption FanSpeed1 Text "%1 rpm"]
+IfFalseAction2=[!SetOption FanSpeed1 Text "%1 rpm"]
+OnUpdateAction=[!UpdateMeter FanSpeed1]
+UpdateDivider=10
+
+[MeasureCPUFanRPM_HWiNFO]
+; Returns the FanSpeed of the GPU using HWiNFO
+; If the Speed is not shown even though HWiNFO is running and the HWiNFO.dll is installed
+; Change the Values below according to HWiNFOSharedMemoryViewer.exe included in the HWiNFO Demo Skin
+Measure=Plugin
+Plugin=HWiNFO.dll
+HWiNFOSensorId=0xf7067980
+HWiNFOSensorInstance=0x0
+HWiNFOEntryId=0x3000001
+;
+HWiNFOType=CurrentValue
+OnUpdateAction=[!UpdateMeasure MeasureCPUFanRPM]
+UpdateDivider=1
 
 ; ------------------------------------------------------------------------
 ; METERS
@@ -111,4 +140,8 @@ Hidden=0
 
 [Value1]
 MeasureName2=MeasureCPUTemp
+Hidden=0
+
+[FanSpeed1]
+MeasureName=MeasureCPUFanRPM
 Hidden=0

--- a/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/gpuTemplate.ini
@@ -130,6 +130,36 @@ DataSource=GPU temperature
 OnUpdateAction=[!UpdateMeasure MeasureGPUTemp]
 UpdateDivider=10
 
+[MeasureGPUFanRPM]
+; Pulls Info About the GPU FanSpeed if possible
+Measure=Calc
+Formula=0
+IfCondition=MeasureGPUFanRPM_HWiNFO > -1
+IfTrueAction=[!SetOption MeasureGPUFanRPM Formula MeasureGPUFanRPM_HWiNFO]
+;IfCondition2=MeasureGPUTemp_HWiNFO > 0
+;IfTrueAction2=[!SetOption MeasureGPUFanRPM Formula MeasureGPUTemp_HWiNFO]
+;IfCondition3=MeasureGPUTemp_MSIAfterburner > 0
+;IfTrueAction3=[!SetOption MeasureGPUFanRPM Formula MeasureGPUTemp_MSIAfterburner]
+IfCondition2=MeasureGPUFanRPM > -1
+IfTrueAction2=[!SetOption FanSpeed5 Text "%1 rpm"]
+IfFalseAction2=[!SetOption FanSpeed5 Text "%1 rpm"]
+OnUpdateAction=[!UpdateMeter FanSpeed5]
+UpdateDivider=10
+
+[MeasureGPUFanRPM_HWiNFO]
+; Returns the FanSpeed of the GPU using HWiNFO
+; If the Speed is not shown even though HWiNFO is running and the HWiNFO.dll is installed
+; Change the Values below according to HWiNFOSharedMemoryViewer.exe included in the HWiNFO Demo Skin
+Measure=Plugin
+Plugin=HWiNFO.dll
+HWiNFOSensorId=0xe0002000
+HWiNFOSensorInstance=0x0
+HWiNFOEntryId=0x3000000
+;
+HWiNFOType=CurrentValue
+OnUpdateAction=[!UpdateMeasure MeasureGPUFanRPM]
+UpdateDivider=1
+
 ; ------------------------------------------------------------------------
 ; METERS
 ; ------------------------------------------------------------------------
@@ -157,4 +187,8 @@ Hidden=0
 
 [Value5]
 MeasureName2=MeasureGPUTemp
+Hidden=0
+
+[FanSpeed5]
+MeasureName=MeasureGPUFanRPM
 Hidden=0

--- a/Win10 Widgets/@Resources/Performance Templates/performanceTemplateX4.ini
+++ b/Win10 Widgets/@Resources/Performance Templates/performanceTemplateX4.ini
@@ -55,6 +55,7 @@ GraphLabel4="Network"
 GraphLeftPadding5=11
 GraphTopPadding5=11
 GraphMeasure5=EmptyMeasure
+GraphMeasure5rpm=EmptyMeasure
 GraphColor5=#GPURed#
 GraphLabel5="GPU"
 
@@ -163,6 +164,18 @@ X=1r
 Y=-2R
 Group=Monitor1
 Text="%1%"
+FontSize=9
+Hidden=1
+
+[FanSpeed1]
+; Value corresponding to graph.
+Meter=String
+MeterStyle=StyleSmallText
+MeasureName=#GraphMeasure1rpm#
+X=1r
+Y=-2R
+Group=Monitor1
+Text="%1 rpm"
 FontSize=9
 Hidden=1
 
@@ -558,5 +571,17 @@ X=1r
 Y=-2R
 Group=Monitor5
 Text="%1%"
+FontSize=9
+Hidden=1
+
+[FanSpeed5]
+; Value corresponding to graph.
+Meter=String
+MeterStyle=StyleSmallText
+MeasureName=#GraphMeasure5rpm#
+X=1r
+Y=-2R
+Group=Monitor5
+Text="%1 rpm"
 FontSize=9
 Hidden=1

--- a/Win10 Widgets/Performance - CPU/CPU-Large.ini
+++ b/Win10 Widgets/Performance - CPU/CPU-Large.ini
@@ -45,3 +45,10 @@ X=0R
 Y=16r
 FontSize=18
 FontColor=#ForegroundFaintColor#
+
+[FanSpeed1]
+MeterStyle=StyleMediumText
+X=1R
+Y=0r
+FontSize=18
+FontColor=#ForegroundFaintColor#

--- a/Win10 Widgets/Performance - GPU/GPU-Large.ini
+++ b/Win10 Widgets/Performance - GPU/GPU-Large.ini
@@ -45,3 +45,10 @@ X=0R
 Y=16r
 FontSize=18
 FontColor=#ForegroundFaintColor#
+
+[FanSpeed5]
+MeterStyle=StyleMediumText
+X=1R
+Y=0r
+FontSize=18
+FontColor=#ForegroundFaintColor#


### PR DESCRIPTION
Added CPU and GPU fan speed (based on HWiNFO data) in Large and Combo panels

<img width="182" alt="CPU_GPU_fan_speed" src="https://user-images.githubusercontent.com/18009979/91662071-4d610800-eae0-11ea-9cf1-6be6943b7804.PNG">

in the image GPU fan is at 0 rpm because it's in quiet mode but it's working fine.